### PR TITLE
Change psi version, remove tile cachebuster

### DIFF
--- a/assets/scripts/config.js
+++ b/assets/scripts/config.js
@@ -5,7 +5,7 @@
 // http://leaflet-extras.github.io/leaflet-providers/preview/
 // Ex: http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png
 // You want to change this - our base tiles only cover Mecklenburg County NC.
-var baseTilesURL = "http://{s}.tiles.mapbox.com/v3/codeforamerica.ijj7831e/{z}/{x}/{y}.png" + cacheBuster;
+var baseTilesURL = "http://{s}.tiles.mapbox.com/v3/codeforamerica.ijj7831e/{z}/{x}/{y}.png";
 
 // The basic geographic setup for your map: the minimum zoom level,
 // maximum zoom level, and the starting zoom level, the map center point, and when

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp-convert": "*",
     "gulp-connect": "*",
     "open": "*",
-    "psi": "*"
+    "psi": "0.0.4"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Two things:
- The `psi` module was updated six hours ago, and there's an error in the build. (See issue [here](https://github.com/addyosmani/psi/issues/30).) The `package.json` file has ambiguity with versions: `'*'` means pick the newest version of the module, which was causing errors. I just defined the version as `0.0.4`, which was the last clean build of `psi`.
- There was an error where `cacheBuster` was getting defined in a script tag in `reports.html` but not in `index.html`, so the map wasn't loading. (The map tiles definition had `cacheBuster` appended, but it wasn't defined.) I removed this -- we want the tiles to be cached so we don't make a zillion calls to Mapbox and CfA doesn't get charged for each request.

This should make everything awesome! Once merged, just do an `npm install` and everything should work. :smiley_cat: 
