### PR TITLE
Unspecify psi version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "gulp-convert": "*",
     "gulp-connect": "*",
     "open": "*",
-    "psi": "0.0.4"
+    "psi": "*"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Newest version of `psi` is working now, per [same issue](https://github.com/addyosmani/psi/issues/30). We should, however, consider specifying versions of modules so we don't run into this problem again. Will open an issue.
