### PR TITLE
Current data date on page load

### DIFF
--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -366,7 +366,7 @@ function processMetric(msg, data) {
     }
 
     // set slider and time related stuff
-    year = 41;
+    year = 41; // months numbered with January 2011 as 0, so 41 represents June 2014
     $(".slider").slider("option", "max", metricData.length - 1).slider("value", year);
     metricData.length > 1 ? $(".time").fadeIn() : $(".time").hide();
     $('.time-year').text(nameMonth(metricData[year].year));

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -366,7 +366,7 @@ function processMetric(msg, data) {
     }
 
     // set slider and time related stuff
-    year = metricData.length -1;
+    year = 41;
     $(".slider").slider("option", "max", metricData.length - 1).slider("value", year);
     metricData.length > 1 ? $(".time").fadeIn() : $(".time").hide();
     $('.time-year').text(nameMonth(metricData[year].year));


### PR DESCRIPTION
This is a straight up hack. The `year` variable works in a stupid way so I just gave it the number it wanted for it to start on June 2014, which is the most recent month with data. I can explain this more if necessary later but for now this'll do.
