### PR TITLE
Add div for additional resources metadata

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -233,6 +233,7 @@
             <div class="col-md-3">
                 <div class="well">
                     <h4>Additional Resources</h4>
+                    <div class='meta-resources'></div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Additional Resources weren't showing up because the container div was missing. This PR adds it.
