### PR TITLE
Change scaling so values distribute by year instead of total

### DIFF
--- a/assets/scripts/functions/barchart.js
+++ b/assets/scripts/functions/barchart.js
@@ -8,6 +8,10 @@ function barChart() {
 
     function my() {
         var data = quantizeCount(metricData[year].map.values());
+        console.log(metricData[year]);
+        console.log(metricData[year].map);
+        console.log(metricData[year].map.values());
+        console.log(data);
         var countyMean = Math.round(d3.mean(metricData[year].map.values()) * 10) / 10;
         var qtiles = quantize.quantiles();
         var theMetric = $("#metric").val();
@@ -19,6 +23,7 @@ function barChart() {
 
         // x/y/scale stuff
         my.x(w, data.length);
+        console.log(data.length);
         my.y(h, _.max(data, function(d){ return d.value; }).value) ;
         my.xScale(w, x_extent);
 

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -425,6 +425,7 @@ function processMetric(msg, data) {
     // Set up extent
     var extentArray = [];
     console.log(metricData);
+    // Shows distribution by year instead of by total
     extentArray = extentArray.concat(metricData[year].map.values());
    // _.each(metricData, function(d) { console.log(d); debugger; extentArray = extentArray.concat(d.map.values()); });
     x_extent = d3.extent(extentArray);

--- a/assets/scripts/main.js
+++ b/assets/scripts/main.js
@@ -424,7 +424,9 @@ function processMetric(msg, data) {
 
     // Set up extent
     var extentArray = [];
-    _.each(metricData, function(d) { extentArray = extentArray.concat(d.map.values()); });
+    console.log(metricData);
+    extentArray = extentArray.concat(metricData[year].map.values());
+   // _.each(metricData, function(d) { console.log(d); debugger; extentArray = extentArray.concat(d.map.values()); });
     x_extent = d3.extent(extentArray);
 
     // set up quantile


### PR DESCRIPTION
This is a step in the right direction! Range of values displayed is per metric, per year. Much better distribution. Plus a bunch of console.logs got in there, but no harm done.
