### PR TITLE
Fix housing and nuisance error

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -109,11 +109,11 @@
                  -->
                     <select id="metric" data-placeholder="SEARCH VARIABLES" class="form-control input-lg form-metric chosen-select hide">
                         <optgroup label="Housing">
-                            <option value="ce-nuisance">
-                                Code Enforcement Cases - Nuisance
-                            </option>
                             <option value="ce-housing">
                                 Code Enforcement Cases - Housing
+                            </option>
+                            <option value="ce-nuisance">
+                                Code Enforcement Cases - Nuisance
                             </option>
                             <option value="buildingpermits">
                                 Building Permits


### PR DESCRIPTION
Housing data was showing up on load when Nuisance was selected and vice-versa. This patch fixes that by reordering them in the HTML we're not using. #hackshackshacks :penguin: 
